### PR TITLE
feat: add view transition

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -4,7 +4,7 @@ import HeaderLink from './HeaderLink.astro'
 ---
 
 <header
-  class="fixed w-full h-16 shadow-md backdrop-blur-sm bg-gray-100/50 dark:bg-gray-900/50"
+  class="fixed w-full h-16 shadow-md backdrop-blur-md bg-gray-100/50 dark:bg-gray-900/50"
 >
   <nav class="h-16 grid grid-cols-3 items-center max-w-7xl mx-auto px-4 py-2">
     <h2><a href="/">{SITE_TITLE}</a></h2>

--- a/src/layouts/BlogPostLayout.astro
+++ b/src/layouts/BlogPostLayout.astro
@@ -1,39 +1,53 @@
 ---
-import { Image } from 'astro:assets'
+import { Picture } from 'astro:assets'
 import type { CollectionEntry } from 'astro:content'
 import FormattedDate from '../components/FormattedDate.astro'
 import RootLayout from './RootLayout.astro'
 
-type Props = CollectionEntry<'blog'>['data']
+type Props = CollectionEntry<'blog'>
 
-const { title, description, pubDate, updatedDate, heroImage } = Astro.props
+const { id, data } = Astro.props
 ---
 
-<RootLayout title={title} description={description}>
+<RootLayout title={data.title} description={data.description}>
   <article>
-    <div class="relative w-full grid place-items-center">
+    <div class="grid place-items-center">
       {
-        heroImage && (
-          <Image src={heroImage} alt="" width={1020} height={510} fit="cover" />
+        data.heroImage && (
+          <Picture
+            src={data.heroImage}
+            alt=""
+            width={1020}
+            height={510}
+            fit="cover"
+            class="hero-image"
+            style={`view-transition-name: hero-image-${id}`}
+            formats={['avif', 'webp']}
+          />
         )
       }
     </div>
     <div class="prose dark:prose-invert md:prose-lg my-8 mx-auto px-4">
       <div>
         <div>
-          <FormattedDate date={pubDate} />
+          <FormattedDate date={data.pubDate} />
           {
-            updatedDate && (
+            data.updatedDate && (
               <div>
-                最終更新: <FormattedDate date={updatedDate} />
+                最終更新: <FormattedDate date={data.updatedDate} />
               </div>
             )
           }
         </div>
-        <h1>{title}</h1>
+        <h1>{data.title}</h1>
         <hr />
       </div>
       <slot />
     </div>
   </article>
 </RootLayout>
+<style>
+  .hero-image {
+    contain: paint;
+  }
+</style>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -15,6 +15,6 @@ const post = Astro.props
 const { Content } = await render(post)
 ---
 
-<BlogPostLayout {...post.data}>
+<BlogPostLayout {...post}>
   <Content />
 </BlogPostLayout>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,5 +1,5 @@
 ---
-import { Image } from 'astro:assets'
+import { Picture } from 'astro:assets'
 import { getCollection } from 'astro:content'
 import FormattedDate from '../../components/FormattedDate.astro'
 import RootLayout from '../../layouts/RootLayout.astro'
@@ -20,13 +20,15 @@ const posts = (await getCollection('blog')).sort(
               class="row-[inherit] grid grid-rows-[inherit] gap-3 place-items-center"
             >
               {post.data.heroImage && (
-                <Image
+                <Picture
                   src={post.data.heroImage}
                   alt=""
                   width={720}
                   height={360}
                   fit="cover"
-                  class="rounded-lg"
+                  class="rounded-lg hero-image"
+                  style={`view-transition-name: hero-image-${post.id}`}
+                  formats={['avif', 'webp']}
                 />
               )}
               <h4 class="text-lg md:text-2xl">{post.data.title}</h4>
@@ -40,3 +42,8 @@ const posts = (await getCollection('blog')).sort(
     </ul>
   </section>
 </RootLayout>
+<style>
+  .hero-image {
+    contain: paint;
+  }
+</style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,2 +1,6 @@
 @import 'tailwindcss';
 @plugin "@tailwindcss/typography";
+
+@view-transition {
+  navigation: auto;
+}


### PR DESCRIPTION
# このPull Requestは

ビュートランジションを導入してモダンな感じのページ遷移を実現します。
特にブログ一覧ページからブログ記事ページへの遷移では、ヒーロー画像をシームレスに接続させます。

参考（感謝！）: [View Transitions API入門 - 連続性のある画面遷移アニメーションを実現するウェブの新技術 - ICS MEDIA](https://ics.media/entry/230510/)